### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^10.0||^11.0||^12.0"
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",


### PR DESCRIPTION
## Summary
- Widen `illuminate/contracts` constraint from `^10.0||^11.0||^12.0` to `^10.0||^11.0||^12.0||^13.0`

Required for upgrading arashop to Laravel 13.